### PR TITLE
Fixed mistake in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -187,7 +187,7 @@ Factory._prepare method::
         @classmethod
         def _prepare(cls, create, **kwargs):
             password = kwargs.pop('password', None)
-            user = super(UserFactory, cls)._prepare(create, kwargs)
+            user = super(UserFactory, cls)._prepare(create, **kwargs)
             if password:
                 user.set_password(user)
                 if create:


### PR DESCRIPTION
We need give unpacked kwargs into _prepare parent method.
